### PR TITLE
Fixed saving each map's Z level - exoplanet maps are now properly saved

### DIFF
--- a/mods/persistence/controllers/subsystems/persistence.dm
+++ b/mods/persistence/controllers/subsystems/persistence.dm
@@ -47,9 +47,6 @@
 	RAISE_EVENT(/decl/observ/world_saving_start_event, src)
 	for(var/obj/effect/overmap/visitable/visit in world)
 		visit.on_saving_start()
-	AddSavedLevel(3)
-	AddSavedLevel(4)
-	AddSavedLevel(5)
 	try
 		//
 		// 	PREPARATION SECTIONS

--- a/mods/persistence/modules/overmap/exoplanets/_exoplanet.dm
+++ b/mods/persistence/modules/overmap/exoplanets/_exoplanet.dm
@@ -6,6 +6,7 @@
 
 	// Force move the sector to its z level(s) so that it can properly reinitialize.
 	forceMove(locate(world.maxx/2, world.maxy/2, max(map_z))) //Levels are loaded from bottom to top, so this should be fine
+	save_my_levels()
 
 /obj/effect/overmap/visitable/sector/exoplanet/on_saving_end()
 	forceMove(old_loc)

--- a/mods/persistence/modules/overmap/sectors.dm
+++ b/mods/persistence/modules/overmap/sectors.dm
@@ -30,10 +30,7 @@
 
 	// Force move the sector to its z level(s) so that it can properly reinitialize.
 	forceMove(locate(world.maxx/2, world.maxy/2, map_z[1]))
-
-	if(check_rent())
-		for(var/sector_z in map_z)
-			SSpersistence.AddSavedLevel(sector_z)
+	save_my_levels()
 
 /obj/effect/overmap/visitable/proc/on_saving_end()
 	for(var/sector_z in map_z)
@@ -49,6 +46,11 @@
 		last_due = world.realtime
 		return TRUE
 	return FALSE
+
+/obj/effect/overmap/visitable/proc/save_my_levels()
+	if(check_rent())
+		for(var/sector_z in map_z)
+			SSpersistence.AddSavedLevel(sector_z)
 
 //#FIXME: This has to go. It's causing hard deletes in unit tests for something that really should be handled differently.
 // This is terrible, but because of when they are generated, there's no good way to override the creation of visiting_shuttle landmarks without

--- a/mods/persistence/modules/overmap/ships/landable.dm
+++ b/mods/persistence/modules/overmap/ships/landable.dm
@@ -34,7 +34,7 @@
 	start_y = loc.y
 
 	old_loc = loc
-	
+
 	// Find where the ship currently is. If the ship is landed, its home z-level won't be saved unless something else is saving it.
 	var/datum/shuttle/ship_shuttle = SSshuttle.shuttles[shuttle]
 	if(!ship_shuttle || !ship_shuttle.current_location)
@@ -44,8 +44,7 @@
 	if(check_rent())
 		if(ship_shuttle.current_location == landmark)
 			use_mapped_z_levels = TRUE
-			for(var/ship_z in map_z)
-				SSpersistence.AddSavedLevel(ship_z)
+			save_my_levels()
 
 			shuttle_turf = get_turf(ship_shuttle.current_location) // If the entire z-level is saving, the landmark of the shuttle certainly will as well.
 		else


### PR DESCRIPTION
<!-- !! PLEASE, READ THIS !! -->
<!-- We recommend to check the contributing page before opening pull requests. -->
<!-- https://github.com/NebulaSS13/Nebula/blob/dev/CONTRIBUTING.md -->
<!-- If you're opening a pull request which changes A LOT of icon/map files: -->
<!-- Add [IDB IGNORE] (to ignore icon file changes) or [MDB IGNORE] (to ignore map file changes) in the PR title. -->
<!-- These tags prevent huge diffs from overloading IconDiffBot and MapDiffBot. -->

## Description of changes
Exoplanet maps were not being saved due to the fact that they were not being added to the save queue.

## Changelog
:cl:
admin: messed with admin stuff
server: Fixed saving exoplanets' z-levels
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->